### PR TITLE
Update LSP to v1.11.*

### DIFF
--- a/linol-lwt.opam
+++ b/linol-lwt.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "dune" { >= "2.0" }
   "linol" { = version }
-  "jsonrpc" { >= "1.8" & < "1.11" }
+  "jsonrpc" { >= "1.11" & < "1.12" }
   "lwt" { >= "5.1" & < "6.0" }
   "base-unix"
   "yojson" { >= "1.6" }

--- a/linol.opam
+++ b/linol.opam
@@ -14,7 +14,7 @@ depends: [
   "dune" { >= "2.0" }
   "yojson" { >= "1.6" }
   "logs"
-  "lsp" { >= "1.8" & < "1.11" }
+  "lsp" { >= "1.11" & < "1.12" }
   "ocaml" { >= "4.08" }
   "odoc" { with-doc }
 ]

--- a/src/server.ml
+++ b/src/server.ml
@@ -415,7 +415,7 @@ module Make(IO : IO) = struct
         | Lsp.Client_notification.ChangeWorkspaceFolders _
         | Lsp.Client_notification.ChangeConfiguration _
         | Lsp.Client_notification.Initialized
-        | Lsp.Client_notification.Unknown_notification _
+        | Lsp.Client_notification.UnknownNotification _
         | Lsp.Client_notification.CancelRequest _
         | Lsp.Client_notification.WorkDoneProgressCancel _
         | Lsp.Client_notification.SetTrace _


### PR DESCRIPTION
I'm updating the LSP to v1.11.0 as it turns out the original issue I needed fixing was only patched in the v1.11 series. Incidentally, they also changed the name of the `Unknown_notification` constructor so this introduces a break in which versions of `LSP` can be supported. 
