### PR TITLE
[#22] Threat shutdown and exit requests correctly

### DIFF
--- a/example/template/main.ml
+++ b/example/template/main.ml
@@ -81,7 +81,10 @@ class lsp_server =
 let run () =
   let s = new lsp_server in
   let server = Linol_lwt.Jsonrpc2.create_stdio s in
-  let task = Linol_lwt.Jsonrpc2.run server in
+  let task =
+    let shutdown () = s#get_status = `ReceivedExit in
+    Linol_lwt.Jsonrpc2.run ~shutdown server
+  in
   match Linol_lwt.run task with
   | () -> ()
   | exception e ->

--- a/src/jsonrpc2.ml
+++ b/src/jsonrpc2.ml
@@ -302,6 +302,10 @@ module Make (IO : IO) : S with module IO = IO = struct
       IO.return
       @@ Error (E (ErrorCode.InvalidRequest, "content-type must be 'utf-8'"))
 
+  (** [shutdown ()] is called after processing each request to check if the server
+    could wait for new messages.
+    When launching an LSP server using [Server.Make.server], the
+    natural choice for it is [s#get_status = `ReceivedExit] *)
   let run ?(shutdown = fun _ -> false) (self : t) : unit IO.t =
     let process_msg r =
       let module M = Jsonrpc.Packet in


### PR DESCRIPTION
Problem:
As in [#22], we want to shut down our LSP server correctly. That means we should close the pipe and end process after an exit request. This require proper `shutdown : unit -> bool` function passed to `Jsonrpc2.Make.run` which returns `true` after
the server received an exit request.

Right now both exit and shutdown requests are setting LSP server's internal var `_quit` to true. It's very intuitive to use this var in `shutdown`, but we can't do it, since in this case the server would stop receiving new messages right after the shutdown request, despite the fact  according to the LSP specification it had to wait the exit request.

Solution:
Instead of `_quit : bool` use
```
status : [ `Running | `ReceivedShutdown | `ReceivedExit ]
```
and suggest
```
shutdown () = s#get_status = `ReceivedExit
```
in docs for `Jsonrpc2.Make.run` and in the templete/example.