### PR TITLE
Drop redundant dependency on atomic

### DIFF
--- a/linol.opam
+++ b/linol.opam
@@ -14,7 +14,6 @@ depends: [
   "dune" { >= "2.0" }
   "yojson" { >= "1.6" }
   "logs"
-  "atomic"
   "trace" { >= "0.4" }
   "lsp" { >= "1.17" & < "1.18" }
   "jsonrpc" { >= "1.17" & < "1.18" }

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
  (public_name linol)
  (private_modules log)
  (flags :standard -warn-error -a+8)
- (libraries yojson lsp logs atomic threads trace.core))
+ (libraries yojson lsp logs threads trace.core))


### PR DESCRIPTION
The linol library already depends on OCaml ≥ 4.14