### PR TITLE
Update main.ml

### DIFF
--- a/example/template-eio/main.ml
+++ b/example/template-eio/main.ml
@@ -82,11 +82,11 @@ let run () =
   Eio_main.run @@ fun env ->
   let s = new lsp_server in
   let server = Linol_eio.Jsonrpc2.create_stdio ~env s in
-  let task =
+  let task () =
     let shutdown () = s#get_status = `ReceivedExit in
     Linol_eio.Jsonrpc2.run ~shutdown server
   in
-  match task with
+  match task () with
   | () -> ()
   | exception e ->
     let e = Printexc.to_string e in


### PR DESCRIPTION
Make `task` a function in order to catch its exceptions.

--

This fixes a typo for a small bug I happened to randomly spot while looking at the new eio examples of linol, simply out of curiosity. Feel free to ignore or fix in some other way.