### PR TITLE
Make template-eio handle requests concurrently

### DIFF
--- a/example/template-eio/main.ml
+++ b/example/template-eio/main.ml
@@ -45,7 +45,7 @@ class lsp_server ~(sw: Eio.Switch.t) =
     val buffers : (Lsp.Types.DocumentUri.t, state_after_processing) Hashtbl.t =
       Hashtbl.create 32
 
-    method spawn_query_handler f = Eio.Fiber.fork ~sw f
+    method spawn_query_handler f = Linol_eio.spawn ~sw f
 
     (* We define here a helper method that will:
        - process a document

--- a/src/eio/linol_eio.ml
+++ b/src/eio/linol_eio.ml
@@ -51,6 +51,16 @@ module IO_eio :
   let read_line in_ch = Eio.Buf_read.line in_ch
 end
 
+(** Spawn function. *)
+let spawn ~sw f =
+  Eio.Fiber.fork ~sw (fun () ->
+   try
+     f ()
+   with exn ->
+     Printf.eprintf "uncaught exception in `spawn`:\n%s\n%!"
+       (Printexc.to_string exn);
+     raise exn)
+
 include Lsp.Types
 include IO_eio
 


### PR DESCRIPTION
Fix #59

So, I have just removed `Linol_eio.spawn` altogether here and just provided the non-blocking implementation in the template, since `spawn` is only used in the user code anyway.

Perhaps there could be a default implementation for `spawn_query_handler` and this code would then live inside the library. I think then `spawn` should be part of `IO`, and be of type `env -> (unit -> unit) -> unit`, and `env` would also contain the `Eio.Switch.t`. Let me know if you want me to try that instead.

I glanced at the Lwt implementation and I think it should have same problem (also probably race condition on writing similar to #58), but I have no experience with Lwt (although I'm new to Eio/OCaml in general as well)