### PR TITLE
Remove yojson < 3.0.0 constraint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
  (synopsis "LSP server library")
  (depends
   ("yojson"
-   (and (>= "1.6") (< "3.0")))
+   (>= "1.6"))
   "logs"
   ("trace"
    (>= "0.4"))

--- a/thirdparty/lsp/jsonrpc/src/dune
+++ b/thirdparty/lsp/jsonrpc/src/dune
@@ -1,4 +1,5 @@
 (library
  (public_name jsonrpc)
+ (libraries yojson)
  (instrumentation
   (backend bisect_ppx)))

--- a/thirdparty/lsp/jsonrpc/src/import.ml
+++ b/thirdparty/lsp/jsonrpc/src/import.ml
@@ -9,18 +9,7 @@ module Option = struct
 end
 
 module Json = struct
-  type t =
-    [ `Assoc of (string * t) list
-    | `Bool of bool
-    | `Float of float
-    | `Int of int
-    | `Intlit of string
-    | `List of t list
-    | `Null
-    | `String of string
-    | `Tuple of t list
-    | `Variant of string * t option
-    ]
+  type t = Yojson.Safe.t
 
   exception Of_json of (string * t)
 

--- a/thirdparty/lsp/jsonrpc/src/jsonrpc.mli
+++ b/thirdparty/lsp/jsonrpc/src/jsonrpc.mli
@@ -1,18 +1,7 @@
 (** Jsonrpc implementation *)
 
 module Json : sig
-  type t =
-    [ `Assoc of (string * t) list
-    | `Bool of bool
-    | `Float of float
-    | `Int of int
-    | `Intlit of string
-    | `List of t list
-    | `Null
-    | `String of string
-    | `Tuple of t list
-    | `Variant of string * t option
-    ]
+  type t = Yojson.Safe.t
 
   (** Raised when conversions from json fail *)
   exception Of_json of (string * t)

--- a/vendor/jsonrpc/dune
+++ b/vendor/jsonrpc/dune
@@ -2,4 +2,5 @@
 
 (library
  (name linol_jsonrpc)
+ (libraries yojson)
  (public_name linol.jsonrpc))


### PR DESCRIPTION
The fix to #57, namely, adding the constraint `yojson < 3.0.0`, seems improvable. Currently, it has the consequence that a project that depends on linol cannot use yojson >= 3.0.0.

An unfortunate side effect of this is that linol cannot be part of OSes’ package repositories without creating conflicts. For instance, Nixpkgs (which, like many package managers, relies on a global coherent set of package versions) has settled on yojson 3.0.0 but some packages still pin yojson 2.x, and if a package happens to contain both in its dependency tree, it becomes uninstallable on Nix. This happened to me when I tried to upgrade Slipshow.

A simple fix to this is to define `type Json.t = Yojson.Safe.t` as is done in more recent versions of jsonrpc, and now linol supports yojson 2.x and 3.0 without distinctions. This would help reducing the schism in Nixpkgs, as well as relax package constraints for users.